### PR TITLE
 Clear list of run_on_commit callbacks after rollback

### DIFF
--- a/import_export/__init__.py
+++ b/import_export/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '1.2.0'
+__version__ = '1.2.0+frontiersignal.0'

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -27,7 +27,7 @@ from .results import Error, Result, RowResult
 from .utils import atomic_if_using_transaction
 
 try:
-    from django.db.transaction import atomic, savepoint, savepoint_rollback, savepoint_commit  # noqa
+    from django.db.transaction import atomic, get_connection, savepoint, savepoint_rollback, savepoint_commit  # noqa
 except ImportError:
     from .django_compat import atomic, savepoint, savepoint_rollback, savepoint_commit  # noqa
 
@@ -644,6 +644,8 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         if using_transactions:
             if dry_run or result.has_errors():
                 savepoint_rollback(sp1)
+                # FS edit: Skip running run_on_commit callbacks.
+                get_connection().run_on_commit = []
             else:
                 savepoint_commit(sp1)
 


### PR DESCRIPTION
The import_export library always performs a "dry run" transaction when
importing via django admin, which is accomplished by manually rolling
the database back to a savepoint created in the transaction before the
database is changed. However, rolling back to a savepoint does not clear
commit callbacks added *after* that savepoint. Those callbacks should be
cleared (at least in all cases at Frontier Signal).

For example, we often use `call_on_commit` to schedule a followup task
via celery after creating/saving an object. Current behavior causes the
celery task to be scheduled (and immediately fail) during the dry run
import.